### PR TITLE
Upgrade Bundler to resolve CVE-2020-36327 and CVE-2019-3881

### DIFF
--- a/io-grab.gemspec
+++ b/io-grab.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 2.2.18"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### What does this PR do?
-Upgrades Bundler to 2.2.18

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation
